### PR TITLE
Trigger CI/CD pipeline on main

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -3,7 +3,7 @@ name: Deploy Hugo site to GitHub Pages
 on:
   # Runs on pushes targeting the production branch
   push:
-    branches: ["production"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 [www.les.cx](https://www.les.cx) has been moved [from a VPS](https://www.netcup.de) to GitHub Pages. This change was made because I only serve static content and there isn't any need to administrate a whole VPS for a single website. It also cuts the costs for this site and my workload.
 
-## Branches
+I'm using a CI/CD to deploy my website to GitHub Pages.
 
-As I'm using a CI/CD to deploy my website, I do have a few rules on where development takes place.
-
-### Short:
-
-* main (merge branch; no direct commits)
-* [fix,feature,pipeline,…]/branch-description
-* production (known as gh-pages in other repos; CD to www.les.cx)
+Commits to **main** can only be done through a pull request from a feature branch (e.g. **hugo/bump-version-0.121.1**).
+After the merge, the pipeline is triggered and builds the hugo website and pushes the `./public` folder to GitHub Pages.


### PR DESCRIPTION
Instead of creating a production and a staging branch, I use feature branches that merge into main. Testing is done locally using Hugo's different configuration files. Before commiting the production environment (config), I check if the staging branch yields no errors.

This approach is simpler than running multiple CI pipelines for my single static website.